### PR TITLE
Optionally destroy TaxRates depending on Avatax enabled

### DIFF
--- a/app/models/spree_avatax_official/configuration.rb
+++ b/app/models/spree_avatax_official/configuration.rb
@@ -16,5 +16,6 @@ module SpreeAvataxOfficial
     preference :endpoint,                   :string,  default: Rails.env.production? ? 'https://rest.avatax.com' : 'https://sandbox-rest.avatax.com'
     preference :license_key,                :string,  default: ''
     preference :commit_transaction_enabled, :boolean, default: true
+    preference :enforce_strict_rates,       :boolean, default: false
   end
 end

--- a/app/services/spree_avatax_official/settings/update_service.rb
+++ b/app/services/spree_avatax_official/settings/update_service.rb
@@ -17,6 +17,9 @@ module SpreeAvataxOfficial
         SpreeAvataxOfficial::Config.address_validation_enabled = params[:address_validation_enabled] if params.key?(:address_validation_enabled)
         SpreeAvataxOfficial::Config.commit_transaction_enabled = params[:commit_transaction_enabled] if params.key?(:commit_transaction_enabled)
         SpreeAvataxOfficial::Config.enabled                    = params[:enabled] if params.key?(:enabled)
+        SpreeAvataxOfficial::Config.enforce_strict_rates       = params[:enforce_strict_rates] if params.key?(:enforce_strict_rates)
+
+        remove_tax_rates!(params[:enabled]) if SpreeAvataxOfficial::Config.enforce_strict_rates
       end
 
       def update_address_settings(ship_from_params)
@@ -30,6 +33,33 @@ module SpreeAvataxOfficial
             country:    ship_from_params[:country],
             postalCode: ship_from_params[:postal_code]
         }
+      end
+
+      # This could hinge off of a new config option like 'enforce_strict_rates' or similar,
+      # that way it could be opted out of if desired.
+      def remove_tax_rates!(enabled_params)
+        if SpreeAvataxOfficial::Config.enabled
+          Rails.logger.debug "Remove non-Avatax"
+          ::Spree::TaxRate.all.joins(:calculator)
+          .where.not(calculator: {type: "SpreeAvataxOfficial::Calculator::AvataxTransactionCalculator"})
+          .destroy_all
+        else
+          Rails.logger.debug "Remove Avatax"
+          # If Avatax will be disabled, we don't want its rates left lying about.
+          # They will get picked up along with Spree native rates and do bad things
+          # to tax calulations:
+          # If Spree rate creates an adjustment for $1.00,
+          # each of the Avatax rates for the zone/category will also create a $1.00
+          # adjustment. After the adjustment is created, the recalculation callback
+          # will run. Spree adjustment will remain as $1.00, while Avatax ones
+          # will look at the tax adjustments and sum them for the new amount.
+          # This means the Avatax one will become $2.00. The next time the amount
+          # is recalculated it grow again. On and on and on until we exceed the column
+          # range in the database.
+          ::Spree::TaxRate.all.joins(:calculator)
+          .where(calculator: {type: "SpreeAvataxOfficial::Calculator::AvataxTransactionCalculator"})
+          .destroy_all
+        end
       end
     end
   end

--- a/app/views/spree/admin/avatax_settings/edit.html.erb
+++ b/app/views/spree/admin/avatax_settings/edit.html.erb
@@ -52,6 +52,17 @@
       </fieldset>
 
       <fieldset>
+        <legend><%= Spree.t('spree_avatax_official.enforce_strict_rates.label') %></legend>
+        <div class="checkbox">
+          <label>
+            <%= hidden_field_tag('enforce_strict_rates', false) %>
+            <%= check_box_tag('enforce_strict_rates', true, SpreeAvataxOfficial::Config.enforce_strict_rates) %>
+            <%= Spree.t('spree_avatax_official.enforce_strict_rates.description') %>
+          </label>
+        </div>
+      </fieldset>
+
+      <fieldset>
         <legend><%= Spree.t('spree_avatax_official.address_validation') %></legend>
         <div class="checkbox">
           <label>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,3 +38,6 @@ en:
       avalara_entity_use_code: Avalara Entity Use Code
       ping_avatax: Ping AvaTax
       wrong_endpoint_url: Endpoint URL seems to be invalid
+      enforce_strict_rates:
+        label: Enforce strict rates
+        description: Allow only AvaTax rates when it is enabled. Remove them when it is disabled.


### PR DESCRIPTION
To prevent the issue we saw with calculations growing exponentially, add an optional preference for the gem `enforce_strict_rates`.

If it is enabled, when AvaTax gets enabled, it will destroy all non-avatax rates. When AvaTax gets disabled, it will destroy all AvaTax rates.

I can't think of a reason why anybody would need a mix of types, but thought that making it a setting that could opted in/out of might make it more likely to be included in the gem at some point.