### PR TITLE
Refund errors

### DIFF
--- a/app/controllers/spree/admin/orders/customer_details_controller_decorator.rb
+++ b/app/controllers/spree/admin/orders/customer_details_controller_decorator.rb
@@ -1,0 +1,33 @@
+module Spree
+  module Admin
+    module Orders
+      module CustomerDetailsControllerDecorator
+        def self.prepended(base)
+
+        end
+
+
+        def update
+          params[:order][:user_id] = nil if guest_checkout?
+          if @order.update(order_params)
+            @order.update_with_updater! # Causes Avatax to recalculate tax and totals
+            @order.associate_user!(@user, @order.email.blank?) unless guest_checkout?
+            @order.next if @order.address?
+            @order.refresh_shipment_rates(Spree::ShippingMethod::DISPLAY_ON_BACK_END)
+
+            if @order.errors.empty?
+              flash[:success] = Spree.t('customer_details_updated')
+              redirect_to spree.edit_admin_order_url(@order)
+            else
+              render action: :edit
+            end
+          else
+            render action: :edit
+          end
+        end
+      end
+    end
+  end
+end
+
+::Spree::Admin::Orders::CustomerDetailsController.prepend(Spree::Admin::Orders::CustomerDetailsControllerDecorator)

--- a/app/controllers/spree/admin/orders/customer_details_controller_decorator.rb
+++ b/app/controllers/spree/admin/orders/customer_details_controller_decorator.rb
@@ -2,11 +2,6 @@ module Spree
   module Admin
     module Orders
       module CustomerDetailsControllerDecorator
-        def self.prepended(base)
-
-        end
-
-
         def update
           params[:order][:user_id] = nil if guest_checkout?
           if @order.update(order_params)

--- a/app/services/spree_avatax_official/transactions/refund_service.rb
+++ b/app/services/spree_avatax_official/transactions/refund_service.rb
@@ -12,7 +12,8 @@ module SpreeAvataxOfficial
       private
 
       def full_refund?(refundable)
-        refundable.order_inventory_units == inventory_units(refundable)
+        # If a refund is being done without any RMA, need another way to tell it is full?
+        refundable.order_inventory_units == inventory_units(refundable) || refundable.amount == refundable.payment.amount
       end
 
       def refundable_class(refundable)
@@ -24,7 +25,10 @@ module SpreeAvataxOfficial
                              when 'ReturnAuthorization'
                                refundable.inventory_units
                              when 'Refund'
-                               refundable.reimbursement.return_items.map(&:inventory_unit)
+                               # A refund can be made without having an RMA,
+                               # in which case there is no reimbursement,
+                               # no inventory_units except via the order.
+                               refundable.reimbursement&.return_items&.map(&:inventory_unit)
                              end
       end
 

--- a/lib/spree_avatax_official/version.rb
+++ b/lib/spree_avatax_official/version.rb
@@ -1,5 +1,5 @@
 module SpreeAvataxOfficial
-  VERSION = '1.7.2'.freeze
+  VERSION = '1.7.3'.freeze
 
   module_function
 

--- a/lib/spree_avatax_official/version.rb
+++ b/lib/spree_avatax_official/version.rb
@@ -1,5 +1,5 @@
 module SpreeAvataxOfficial
-  VERSION = '1.7.1'.freeze
+  VERSION = '1.7.2'.freeze
 
   module_function
 


### PR DESCRIPTION
Trying to do a refund on a payment directly will result in an error `undefined method return_items for nil`
For full refunds, this fixes the issue. Rather than trying to determine if there is a return for every line item to determine if this is a full refund, just compare the refund amount to the payment amount.

Refunding partial amounts will still fail, this isn't a priority to fix at the moment.

Refunding a payment should work.
Refunding a reimbursement via customer returns should work.