### PR TITLE
Admin taxes

### DIFF
--- a/app/controllers/spree/admin/orders/customer_details_controller_decorator.rb
+++ b/app/controllers/spree/admin/orders/customer_details_controller_decorator.rb
@@ -1,0 +1,33 @@
+module Spree
+  module Admin
+    module Orders
+      module CustomerDetailsControllerDecorator
+        def self.prepended(base)
+
+        end
+
+
+        def update
+          params[:order][:user_id] = nil if guest_checkout?
+          if @order.update(order_params)
+            @order.update_with_updater! # Causes Avatax to recalculate tax and totals
+            @order.associate_user!(@user, @order.email.blank?) unless guest_checkout?
+            @order.next if @order.address?
+            @order.refresh_shipment_rates(Spree::ShippingMethod::DISPLAY_ON_BACK_END)
+
+            if @order.errors.empty?
+              flash[:success] = Spree.t('customer_details_updated')
+              redirect_to spree.edit_admin_order_url(@order)
+            else
+              render action: :edit
+            end
+          else
+            render action: :edit
+          end
+        end
+      end
+    end
+  end
+end
+
+::Spree::Admin::Orders::CustomerDetailsController.prepend(Spree::Admin::Orders::CustomerDetailsControllerDecorator)

--- a/app/controllers/spree/admin/orders/customer_details_controller_decorator.rb
+++ b/app/controllers/spree/admin/orders/customer_details_controller_decorator.rb
@@ -2,11 +2,6 @@ module Spree
   module Admin
     module Orders
       module CustomerDetailsControllerDecorator
-        def self.prepended(base)
-
-        end
-
-
         def update
           params[:order][:user_id] = nil if guest_checkout?
           if @order.update(order_params)

--- a/lib/spree_avatax_official/version.rb
+++ b/lib/spree_avatax_official/version.rb
@@ -1,5 +1,5 @@
 module SpreeAvataxOfficial
-  VERSION = '1.7.2'.freeze
+  VERSION = '1.7.3'.freeze
 
   module_function
 


### PR DESCRIPTION
NOTE: This is built on top of the refund errors branch, so includes those updates as well.

Fixes the issue of Admin side orders not having proper taxes after an update to the address on the Customer Details page.

Override the Spree::Admin::Orders::CustomerDetailsController `update` action to call the OrderUpdater service class (where Avatax does the recalculation and stores new totals).

Starting with NM addresses should have sales tax, switching to like a CA shipping address should change the taxes.
